### PR TITLE
山のデータモデルを変更。通常の山と王牌に分ける

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -7,7 +7,8 @@
 #  status         :integer          default(0), not null
 #  title          :string(100)      not null
 #  turn           :integer          default(0)
-#  wall           :text
+#  main_wall      :text             # 通常の山（最大122枚）
+#  locked_wall    :text             # 王牌（ドラ表示牌・嶺上牌など。14枚固定）
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #
@@ -27,4 +28,7 @@ class Game < ApplicationRecord
     playing: 1,    # ゲーム進行中
     finished: 2    # ゲーム終了
   }
+
+  serialize :main_wall, Array
+  serialize :locked_wall, Array
 end

--- a/db/migrate/20250920115244_update_game_wall_structure.rb
+++ b/db/migrate/20250920115244_update_game_wall_structure.rb
@@ -1,0 +1,7 @@
+class UpdateGameWallStructure < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :games, :wall, :text
+    add_column :games, :main_wall, :text
+    add_column :games, :locked_wall, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_14_201948) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_20_115244) do
   create_table "dora_indicators", force: :cascade do |t|
     t.integer "game_id", null: false
     t.integer "player_id"
@@ -52,9 +52,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_14_201948) do
     t.integer "status", default: 0, null: false
     t.integer "turn", default: 0
     t.integer "current_player", default: 0
-    t.text "wall"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "main_wall"
+    t.text "locked_wall"
     t.index ["created_at"], name: "index_games_on_created_at"
     t.index ["status"], name: "index_games_on_status"
   end

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -7,7 +7,8 @@
 #  status         :integer          default(0), not null
 #  title          :string(100)      not null
 #  turn           :integer          default(0)
-#  wall           :text
+#  main_wall      :text             # 通常の山（最大122枚）
+#  locked_wall    :text             # 王牌（ドラ表示牌・嶺上牌など。14枚固定）
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -7,7 +7,8 @@
 #  status         :integer          default(0), not null
 #  title          :string(100)      not null
 #  turn           :integer          default(0)
-#  wall           :text
+#  main_wall      :text             # 通常の山（最大122枚）
+#  locked_wall    :text             # 王牌（ドラ表示牌・嶺上牌など。14枚固定）
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #


### PR DESCRIPTION
memo)

annotate_rbを利用しているが、add_columnなど、create_table以外のmigrationで、期待どおりのannotation生成が行われない可能性がある。

https://zenn.dev/hatsu/scraps/7d7220b8ad0953

今回は、commentを消しても追加されなかったので、手動でモデルファイルに追加している。